### PR TITLE
Refactor origin details

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -73,7 +73,7 @@ export interface BraintreeVoidedEvent extends BraintreeStatusEvent {
 }
 export interface BraintreeAuthorizedEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.AUTHORIZED;
-    originDetails?: OriginDetails;
+    originResponse?: OriginDetails;
 }
 export interface BraintreeSettlementPendingEvent extends BraintreeStatusEvent {
     id: string;
@@ -81,25 +81,25 @@ export interface BraintreeSettlementPendingEvent extends BraintreeStatusEvent {
 }
 export interface BraintreeFailedEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.FAILED;
-    originDetails?: Partial<OriginDetails>;
+    originResponse?: Partial<OriginDetails>;
 }
 export interface BraintreeProcessorDeclinedEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.PROCESSOR_DECLINED;
-    originDetails?: Partial<OriginDetails>;
+    originResponse?: Partial<OriginDetails>;
 }
 export interface BraintreeSettledEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.SETTLED;
-    originDetails?: OriginDetails;
+    originResponse?: OriginDetails;
 }
 export interface BraintreeSettlementConfirmedEvent extends BraintreeStatusEvent {
     id: string;
     status: BraintreeTransactionStatus.SETTLEMENT_CONFIRMED;
-    originDetails: OriginDetails;
+    originResponse: OriginDetails;
 }
 export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
     id: string;
     status: BraintreeTransactionStatus.SETTLEMENT_DECLINED;
-    originDetails: OriginDetails;
+    originResponse: OriginDetails;
 }
 export interface BraintreeSubmittedForSettlementEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,6 +235,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^8.10.51",
+    "prettier": "^1.18.2",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export interface BraintreeVoidedEvent extends BraintreeStatusEvent {
 
 export interface BraintreeAuthorizedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.AUTHORIZED;
-  originDetails?: OriginDetails;
+  originResponse?: OriginDetails;
 }
 
 export interface BraintreeSettlementPendingEvent extends BraintreeStatusEvent {
@@ -101,30 +101,30 @@ export interface BraintreeSettlementPendingEvent extends BraintreeStatusEvent {
 
 export interface BraintreeFailedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.FAILED;
-  originDetails?: Partial<OriginDetails>;
+  originResponse?: Partial<OriginDetails>;
 }
 
 export interface BraintreeProcessorDeclinedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.PROCESSOR_DECLINED;
-  originDetails?: Partial<OriginDetails>;
+  originResponse?: Partial<OriginDetails>;
 }
 
 export interface BraintreeSettledEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.SETTLED;
-  originDetails?: OriginDetails;
+  originResponse?: OriginDetails;
 }
 
 export interface BraintreeSettlementConfirmedEvent
   extends BraintreeStatusEvent {
   id: string;
   status: BraintreeTransactionStatus.SETTLEMENT_CONFIRMED;
-  originDetails: OriginDetails;
+  originResponse: OriginDetails;
 }
 
 export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
   id: string;
   status: BraintreeTransactionStatus.SETTLEMENT_DECLINED;
-  originDetails: OriginDetails;
+  originResponse: OriginDetails;
 }
 
 export interface BraintreeSubmittedForSettlementEvent


### PR DESCRIPTION
The proper name for this key is originResponse, although it should have optional id, message, and code.

We currently have a concept of a BraintreeOriginResponse but it requires a code and message without an id.

We'll have to sort this out but for now renaming the key solves the immediate issue.