### PR TITLE
Remove originDetails in favor of originResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface BraintreeTransaction {
   id: string;
   lineItems?: BraintreeLineItem[];
   orderId?: string;
-  originDetails?: OriginDetails;
+  originResponse?: OriginResponse;
   paymentMethodFields: BraintreePaymentMethodField[];
   processorId?: string;
   settlementBatchId?: string;
@@ -40,7 +40,7 @@ export interface ExternalTransaction {
   id?: string;
   lineItems?: BraintreeLineItem[];
   orderId?: string;
-  originDetails: OriginDetails;
+  originResponse: OriginResponse;
   processorId?: string;
   settlementBatchId?: string;
   shipping?: BraintreeAddress;
@@ -59,8 +59,7 @@ export enum BraintreeTransactionType {
 
 export interface BraintreeTransactionStatusEvent {
   status: BraintreeTransactionStatus;
-  originResponse?: BraintreeOriginResponse;
-  originDetails?: BraintreeOriginResponse;
+  originResponse?: OriginResponse;
 }
 
 export interface BraintreeEventHandlerResponse {
@@ -94,8 +93,7 @@ export interface BraintreeVoidedEvent extends BraintreeStatusEvent {
 
 export interface BraintreeAuthorizedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.AUTHORIZED;
-  originResponse?: OriginDetails;
-  originDetails?: OriginDetails;
+  originResponse?: OriginResponse;
   customFields?: BraintreeCustomField[];
 }
 
@@ -107,22 +105,19 @@ export interface BraintreeSettlementPendingEvent extends BraintreeStatusEvent {
 
 export interface BraintreeFailedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.FAILED;
-  originResponse?: Partial<OriginDetails>;
-  originDetails?: Partial<OriginDetails>;
+  originResponse?: Partial<OriginResponse>;
   customFields?: BraintreeCustomField[];
 }
 
 export interface BraintreeProcessorDeclinedEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.PROCESSOR_DECLINED;
-  originResponse?: Partial<OriginDetails>;
-  originDetails?: Partial<OriginDetails>;
+  originResponse?: Partial<OriginResponse>;
   customFields?: BraintreeCustomField[];
 }
 
 export interface BraintreeSettledEvent extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.SETTLED;
-  originResponse?: OriginDetails;
-  originDetails?: OriginDetails;
+  originResponse?: OriginResponse;
   customFields?: BraintreeCustomField[];
 }
 
@@ -130,16 +125,14 @@ export interface BraintreeSettlementConfirmedEvent
   extends BraintreeStatusEvent {
   id: string;
   status: BraintreeTransactionStatus.SETTLEMENT_CONFIRMED;
-  originResponse: OriginDetails;
-  originDetails: OriginDetails;
+  originResponse: OriginResponse;
   customFields?: BraintreeCustomField[];
 }
 
 export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
   id: string;
   status: BraintreeTransactionStatus.SETTLEMENT_DECLINED;
-  originResponse: OriginDetails;
-  originDetails: OriginDetails;
+  originResponse: OriginResponse;
   customFields?: BraintreeCustomField[];
 }
 
@@ -157,19 +150,13 @@ export interface BraintreeAutoTransitionBatchTransactionStatus {
   transitionAtTimestamp: string;
 }
 
-export interface BraintreeOriginResponse {
-  id: string;
-  code: string;
-  message: string;
-}
-
 export interface BraintreeTransactionDescriptor {
   name?: string;
   phone?: string;
   url?: string;
 }
 
-export interface OriginDetails {
+export interface OriginResponse {
   // Unique identifier for an "order" in a 3rd party system
   id: string;
   // The text explanation of the processor response code.
@@ -205,7 +192,7 @@ export interface BraintreeRefund {
   refundedTransaction: BraintreeTransaction;
   status: BraintreeTransactionStatus;
   processorId?: string;
-  originDetails?: OriginDetails;
+  originResponse?: OriginResponse;
 }
 
 export interface BraintreeCustomField {


### PR DESCRIPTION
We have deprecated `originDetails` in favor of `originResponse`. This also removes the duplicate interface definition.