### PR TITLE
Introduces BraintreePaymentContext and related changes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,6 @@ export declare type BraintreeTransactionUnion = BraintreeTransaction | Braintree
 export declare type BraintreeTransactionOrRefund = BraintreeTransaction | BraintreeRefund;
 export interface BraintreePaymentContext {
     amount: MonetaryAmount;
-    fundingSource: string;
     customFields?: BraintreeCustomField[];
 }
 export interface MonetaryAmount {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,10 +3,6 @@ export declare type BraintreeTransactionOrRefund = BraintreeTransaction | Braint
 export interface BraintreePaymentContext {
     customFields?: BraintreeCustomField[];
 }
-export interface MonetaryAmount {
-    value: string;
-    currencyIsoCode: string;
-}
 export interface BraintreeTransaction {
     /**
      * Dollar amount including cents represented as a `String`

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,6 @@
 export declare type BraintreeTransactionUnion = BraintreeTransaction | BraintreeCredit | BraintreeRefund;
 export declare type BraintreeTransactionOrRefund = BraintreeTransaction | BraintreeRefund;
 export interface BraintreePaymentContext {
-    amount: MonetaryAmount;
     customFields?: BraintreeCustomField[];
 }
 export interface MonetaryAmount {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,14 @@
 export declare type BraintreeTransactionUnion = BraintreeTransaction | BraintreeCredit | BraintreeRefund;
 export declare type BraintreeTransactionOrRefund = BraintreeTransaction | BraintreeRefund;
+export interface BraintreePaymentContext {
+    amount: MonetaryAmount;
+    fundingSource: string;
+    customFields?: BraintreeCustomField[];
+}
+export interface MonetaryAmount {
+    value: string;
+    currencyIsoCode: string;
+}
 export interface BraintreeTransaction {
     /**
      * Dollar amount including cents represented as a `String`
@@ -64,6 +73,7 @@ export interface BraintreeEventHandlerResponse {
     transactionStatusEvents?: StatusUnion[];
     autoTransitionBatchTransactionStatus?: BraintreeAutoTransitionBatchTransactionStatus;
     importExternalTransaction?: BraintreeImportExternalTransaction;
+    paymentContext?: BraintreePaymentContext;
 }
 declare type StatusUnion = BraintreeVoidedEvent | BraintreeAuthorizedEvent | BraintreeSettlementPendingEvent | BraintreeFailedEvent | BraintreeProcessorDeclinedEvent | BraintreeSettledEvent | BraintreeSettlementConfirmedEvent | BraintreeSettlementDeclinedEvent | BraintreeSubmittedForSettlementEvent;
 interface BraintreeStatusEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export type BraintreeTransactionOrRefund =
   | BraintreeRefund;
 
 export interface BraintreePaymentContext {
-  amount: MonetaryAmount;
   customFields?: BraintreeCustomField[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export type BraintreeTransactionOrRefund =
 
 export interface BraintreePaymentContext {
   amount: MonetaryAmount;
-  fundingSource: string;
   customFields?: BraintreeCustomField[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,6 @@ export interface BraintreePaymentContext {
   customFields?: BraintreeCustomField[];
 }
 
-export interface MonetaryAmount {
-  value: string;
-  currencyIsoCode: string;
-}
-
 export interface BraintreeTransaction {
   /**
    * Dollar amount including cents represented as a `String`

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ export type BraintreeTransactionOrRefund =
   | BraintreeTransaction
   | BraintreeRefund;
 
-interface BraintreePaymentContext {
+export interface BraintreePaymentContext {
   amount: MonetaryAmount;
   fundingSource: string;
   customFields?: BraintreeCustomField[];
 }
 
-interface MonetaryAmount {
+export interface MonetaryAmount {
   value: string;
   currencyIsoCode: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,17 @@ export type BraintreeTransactionOrRefund =
   | BraintreeTransaction
   | BraintreeRefund;
 
+interface BraintreePaymentContext {
+  amount: MonetaryAmount;
+  fundingSource: string;
+  customFields?: BraintreeCustomField[];
+}
+
+interface MonetaryAmount {
+  value: string;
+  currencyIsoCode: string;
+}
+
 export interface BraintreeTransaction {
   /**
    * Dollar amount including cents represented as a `String`
@@ -76,6 +87,7 @@ export interface BraintreeEventHandlerResponse {
   transactionStatusEvents?: StatusUnion[];
   autoTransitionBatchTransactionStatus?: BraintreeAutoTransitionBatchTransactionStatus;
   importExternalTransaction?: BraintreeImportExternalTransaction;
+  paymentContext?: BraintreePaymentContext;
 }
 
 type StatusUnion =


### PR DESCRIPTION
Adds the types and changes which third parties will use when writing a handler for `createPaymentContext`. 