### PR TITLE
settlementTimestamp can take both Date and string

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,7 +114,7 @@ export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
 }
 export interface BraintreeSubmittedForSettlementEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT;
-    settlementTimestamp: Date;
+    settlementTimestamp: Date | string;
     batchingStrategy?: BraintreeBatchingStrategy;
     customFields?: BraintreeCustomField[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
 export interface BraintreeSubmittedForSettlementEvent
   extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT;
-  settlementTimestamp: Date;
+  settlementTimestamp: Date | string;
   batchingStrategy?: BraintreeBatchingStrategy;
   customFields?: BraintreeCustomField[];
 }


### PR DESCRIPTION
It currently takes Date, and I don't think we're not ready to break that convention.