### PR TITLE
Add paymentContextOrError

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,9 @@
 export declare type BraintreeTransactionUnion = BraintreeTransaction | BraintreeCredit | BraintreeRefund;
 export declare type BraintreeTransactionOrRefund = BraintreeTransaction | BraintreeRefund;
+export declare type BraintreePaymentContextOrError = BraintreePaymentContext | HandlerError;
+export interface HandlerError {
+    message: string;
+}
 export interface BraintreePaymentContext {
     customFields?: BraintreeCustomField[];
 }
@@ -67,7 +71,7 @@ export interface BraintreeEventHandlerResponse {
     transactionStatusEvents?: StatusUnion[];
     autoTransitionBatchTransactionStatus?: BraintreeAutoTransitionBatchTransactionStatus;
     importExternalTransaction?: BraintreeImportExternalTransaction;
-    paymentContext?: BraintreePaymentContext;
+    paymentContextOrError?: BraintreePaymentContextOrError;
 }
 declare type StatusUnion = BraintreeVoidedEvent | BraintreeAuthorizedEvent | BraintreeSettlementPendingEvent | BraintreeFailedEvent | BraintreeProcessorDeclinedEvent | BraintreeSettledEvent | BraintreeSettlementConfirmedEvent | BraintreeSettlementDeclinedEvent | BraintreeSubmittedForSettlementEvent;
 interface BraintreeStatusEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,14 @@ export type BraintreeTransactionOrRefund =
   | BraintreeTransaction
   | BraintreeRefund;
 
+export type BraintreePaymentContextOrError =
+  | BraintreePaymentContext
+  | HandlerError;
+
+// A custom error to return from a Custom Actions handler
+export interface HandlerError {
+  message: string;
+}
 export interface BraintreePaymentContext {
   customFields?: BraintreeCustomField[];
 }
@@ -80,7 +88,7 @@ export interface BraintreeEventHandlerResponse {
   transactionStatusEvents?: StatusUnion[];
   autoTransitionBatchTransactionStatus?: BraintreeAutoTransitionBatchTransactionStatus;
   importExternalTransaction?: BraintreeImportExternalTransaction;
-  paymentContext?: BraintreePaymentContext;
+  paymentContextOrError?: BraintreePaymentContextOrError;
 }
 
 type StatusUnion =


### PR DESCRIPTION
This allows Custom Actions handlers* to return a `paymentContextOrError` which is a union of a `BraintreePaymentContext` and `HandlerError`. With this functionality, handlers can surface error messages to clients.

**Note:** This introduces a breaking change and will be bumped a major version when merged.

<sub>* = Limited to PaymentContext handlers only for now</sub>