### PR TITLE
Optional settlementTimestamp

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -122,7 +122,7 @@ export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
 }
 export interface BraintreeSubmittedForSettlementEvent extends BraintreeStatusEvent {
     status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT;
-    settlementTimestamp: Date | string;
+    settlementTimestamp?: Date | string;
     batchingStrategy?: BraintreeBatchingStrategy;
     customFields?: BraintreeCustomField[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ export interface BraintreeSettlementDeclinedEvent extends BraintreeStatusEvent {
 export interface BraintreeSubmittedForSettlementEvent
   extends BraintreeStatusEvent {
   status: BraintreeTransactionStatus.SUBMITTED_FOR_SETTLEMENT;
-  settlementTimestamp: Date | string;
+  settlementTimestamp?: Date | string;
   batchingStrategy?: BraintreeBatchingStrategy;
   customFields?: BraintreeCustomField[];
 }


### PR DESCRIPTION
This makes the `settlementTimestamp` on `BraintreeSubmittedForSettlementEvent` be optional, so that formulae have the freedom to settle transactions by other means instead of using Braintree's settlement mechanism.

**TL;DR**: by not providing a `settlementTimestamp`, the Braintree gateway will not try to invoke a `captureBatch` handler in the formula.