### PR TITLE
BTCA - 948 Allows lineItems on BraintreeRefund

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -207,6 +207,7 @@ export interface BraintreeRefund {
     orderId?: string;
     shipping?: BraintreeAddress;
     taxAmount?: string;
+    lineItems?: BraintreeLineItem[];
     refundedTransaction: BraintreeTransaction;
     status: BraintreeTransactionStatus;
     processorId?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,7 @@ export interface BraintreeRefund {
   orderId?: string;
   shipping?: BraintreeAddress;
   taxAmount?: string;
+  lineItems?: BraintreeLineItem[];
   refundedTransaction: BraintreeTransaction;
   status: BraintreeTransactionStatus;
   processorId?: string;


### PR DESCRIPTION
So that merchant handlers can access the line items data associated to a
refund.