### PR TITLE
BraintreeCaptureBatchEventHandlerResponseOrError

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,12 @@
 export declare type BraintreeTransactionUnion = BraintreeTransaction | BraintreeCredit | BraintreeRefund;
 export declare type BraintreeTransactionOrRefund = BraintreeTransaction | BraintreeRefund;
 export declare type BraintreePaymentContextOrError = BraintreePaymentContextResult | HandlerError;
+export declare type BraintreeCaptureBatchEventHandlerResponseOrError = Pick<BraintreeEventHandlerResponse, "transactionStatusEvents" | "autoTransitionBatchTransactionStatus"> | RecoverableError;
 export interface HandlerError {
     message: string;
+}
+export interface RecoverableError extends HandlerError {
+    recoverable: boolean;
 }
 export interface BraintreePaymentContextResult {
     /** Custom fields to be written to the Payment Context */

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,21 @@ export type BraintreePaymentContextOrError =
   | BraintreePaymentContextResult
   | HandlerError;
 
+export type BraintreeCaptureBatchEventHandlerResponseOrError =
+  | Pick<
+      BraintreeEventHandlerResponse,
+      "transactionStatusEvents" | "autoTransitionBatchTransactionStatus"
+    >
+  | RecoverableError;
+
 // A custom error to return from a Custom Actions handler
 export interface HandlerError {
   message: string;
+}
+
+// A custom error to return from a Custom Actions handler that also states if the request can be recoverable or retried
+export interface RecoverableError extends HandlerError {
+  recoverable: boolean;
 }
 
 export interface BraintreePaymentContextResult {


### PR DESCRIPTION
When CaptureBatch fails, the integrator can inform Custom Actions that the error is "recoverable" meaning that the request can be tried again in the future.

Adding a new type that can be returned from CaptureBatch to that is a selection of properties from BraintreeEventHandlerResponse expected for a CaptureBatch request, or RecoverableError which contains the recoverable boolean.