### PR TITLE
Adds itemType to BraintreeLineItem

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -283,7 +283,7 @@ export interface BraintreeLineItem {
     unitTaxAmount?: string;
     unitOfMeasure?: string;
     url?: string;
-    itemType: string;
+    itemType?: string;
 }
 export interface BraintreeAuthorizeResponse {
     orderId: string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -283,6 +283,7 @@ export interface BraintreeLineItem {
     unitTaxAmount?: string;
     unitOfMeasure?: string;
     url?: string;
+    itemType: string;
 }
 export interface BraintreeAuthorizeResponse {
     orderId: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,7 @@ export interface BraintreeLineItem {
   unitTaxAmount?: string;
   unitOfMeasure?: string;
   url?: string;
+  itemType: string;
 }
 
 export interface BraintreeAuthorizeResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,7 @@ export interface BraintreeLineItem {
   unitTaxAmount?: string;
   unitOfMeasure?: string;
   url?: string;
-  itemType: string;
+  itemType?: string;
 }
 
 export interface BraintreeAuthorizeResponse {


### PR DESCRIPTION
Adds `itemType` to `BraintreeLineItem` so that the handlers can use this information.