### PR TITLE
BTCA - 1305: Adds imageUrl to line items

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -281,6 +281,7 @@ export interface BraintreeLineItem {
     unitOfMeasure?: string;
     url?: string;
     itemType?: string;
+    imageUrl?: string;
 }
 export interface BraintreeAuthorizeResponse {
     orderId: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,6 +352,7 @@ export interface BraintreeLineItem {
   unitOfMeasure?: string;
   url?: string;
   itemType?: string;
+  imageUrl?: string;
 }
 
 export interface BraintreeAuthorizeResponse {


### PR DESCRIPTION
Adds `imageUrl` to line items.

@braintree/custom-actions 