### PR TITLE
Make `BraintreeTransaction`'s `amount` and `currencyIsoCode` required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,9 +86,9 @@ export interface BraintreeTransaction {
    *
    * ex: "10.00"
    */
-  amount?: string;
+  amount: string;
   billing?: BraintreeAddress;
-  currencyIsoCode?: string;
+  currencyIsoCode: string;
   customFields?: BraintreeCustomField[];
   customer?: BraintreeCustomer;
   descriptor?: BraintreeTransactionDescriptor;


### PR DESCRIPTION
Since this data will always be provided based on GraphQL schema's and GW source